### PR TITLE
Handle argument packs for C++11.

### DIFF
--- a/sphinxcontrib/doxylink/parsing.py
+++ b/sphinxcontrib/doxylink/parsing.py
@@ -47,7 +47,7 @@ number = Word('-.' + nums)
 input_name = OneOrMore(Word(alphanums + '_') | angle_bracket_pair | parentheses_pair | square_bracket_pair)
 
 # Grab the '&', '*' or '**' type bit in (const QString & foo, int ** bar)
-pointer_or_reference = oneOf('* &')
+pointer_or_reference = Combine(oneOf('* &') + Optional('...'))
 
 # The '=QString()' or '=false' bit in (int foo = 4, bool bar = false)
 default_value = Literal('=') + OneOrMore(number | quotedString | input_type | parentheses_pair | angle_bracket_pair | square_bracket_pair | Word('|&^'))


### PR DESCRIPTION
This changes the argument parsing so that it can handle declarations like
```
template <typename... Args> std::string_view FirstOf(Args &&... args);
```
Essentially after the cv qualifier, there is an optional "...".

[Here is the actual code base](https://github.com/SolidWallOfCode/libswoc) that I am using this with.