### PR TITLE
Support linking to Doxygen's PDF output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+1.9 (Sep 02, 2021)
+==================
+
+- Add support for linking to Doxygen's PDF output [PR #32]
+
 1.8 (Jan 28, 2021)
 ==================
 

--- a/sphinxcontrib/doxylink/doxylink.py
+++ b/sphinxcontrib/doxylink/doxylink.py
@@ -336,6 +336,9 @@ def create_role(app, tag_filename, rootdir, cache_name):
         # Also check if it is a URL (i.e. it has a 'scheme' like 'http' or 'file')
         if os.path.isabs(rootdir) or urllib.parse.urlparse(rootdir).scheme:
             full_url = join(rootdir, url.file)
+        elif rootdir.endswith('.pdf'):
+            full_url = join(rootdir, '#', url.file)
+            full_url = full_url.replace('.html#', '_')
         # But otherwise we need to add the relative path of the current document to the root source directory to the link
         else:
             relative_path_to_docsrc = os.path.relpath(app.env.srcdir, os.path.dirname(inliner.document.attributes['source']))

--- a/sphinxcontrib/doxylink/doxylink.py
+++ b/sphinxcontrib/doxylink/doxylink.py
@@ -260,7 +260,7 @@ def join(*args):
 
 def create_role(app, tag_filename, rootdir, cache_name):
     # Tidy up the root directory path
-    if not rootdir.endswith(('/', '\\')):
+    if not rootdir.endswith(('/', '\\')) and not rootdir.endswith('.pdf'):
         rootdir = join(rootdir, os.sep)
 
     try:


### PR DESCRIPTION
I have [configured Doxygen](https://www.doxygen.nl/manual/config.html#cfg_generate_latex) to generate LaTeX output called `refman.pdf` next to my main documentation file, generated from reStructuredText files with this doxylink extension. Instead of linking to the Doxygen documentation in HTML format, I want to link it to `refman.pdf` like so:
```
doxylink = {
    'doxy-link' : ['build/doc/html/doxygen/project.tag', 'doxygen/refman.pdf']
}
```

Example:

- For HTML, this doxylink extension produces a link that ends with `doxygen/group__error__handler.html#ga155ade3234974428b436c383675c4450`.

- For PDF, it would produce a link that ends with `doxygen/refman.pdf#group__error__handler_ga155ade3234974428b436c383675c4450`. This link works in Adobe Reader for example but not in my browser. My Adobe Reader was configured to open cross-document links in the same window. This can be changed in the menu `Edit > Preferences > Documents > Open Settings`. Having the Doxygen pdf file open in a separate window is highly convenient.

Resolves #17