### PR TITLE
Fix links to files in Doxygen's PDF output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+1.10 (Sep 10, 2021)
+==================
+
+- Fix links to files in Doxygen's PDF output [PR #33]
+
 1.9 (Sep 02, 2021)
 ==================
 

--- a/sphinxcontrib/doxylink/__init__.py
+++ b/sphinxcontrib/doxylink/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.9'
+__version__ = '1.10'
 
 
 def setup(app):

--- a/sphinxcontrib/doxylink/doxylink.py
+++ b/sphinxcontrib/doxylink/doxylink.py
@@ -338,6 +338,8 @@ def create_role(app, tag_filename, rootdir, cache_name):
             full_url = join(rootdir, url.file)
         elif rootdir.endswith('.pdf'):
             full_url = join(rootdir, '#', url.file)
+            full_url = full_url.replace('.html#', '_')  # for links to variables and functions
+            full_url = full_url.replace('.html', '')  # for links to files
         # But otherwise we need to add the relative path of the current document to the root source directory to the link
         else:
             relative_path_to_docsrc = os.path.relpath(app.env.srcdir, os.path.dirname(inliner.document.attributes['source']))
@@ -346,9 +348,6 @@ def create_role(app, tag_filename, rootdir, cache_name):
         if url.kind == 'function' and app.config.add_function_parentheses and normalise(title)[1] == '' and not has_explicit_title:
             title = join(title, '()')
 
-        if rootdir.endswith('.pdf'):
-            full_url = full_url.replace('.html#', '_')  # for links to variables and functions
-            full_url = full_url.replace('.html', '')  # for links to files
         pnode = nodes.reference(title, title, internal=False, refuri=full_url)
         return [pnode], []
 

--- a/sphinxcontrib/doxylink/doxylink.py
+++ b/sphinxcontrib/doxylink/doxylink.py
@@ -338,7 +338,6 @@ def create_role(app, tag_filename, rootdir, cache_name):
             full_url = join(rootdir, url.file)
         elif rootdir.endswith('.pdf'):
             full_url = join(rootdir, '#', url.file)
-            full_url = full_url.replace('.html#', '_')
         # But otherwise we need to add the relative path of the current document to the root source directory to the link
         else:
             relative_path_to_docsrc = os.path.relpath(app.env.srcdir, os.path.dirname(inliner.document.attributes['source']))
@@ -347,6 +346,9 @@ def create_role(app, tag_filename, rootdir, cache_name):
         if url.kind == 'function' and app.config.add_function_parentheses and normalise(title)[1] == '' and not has_explicit_title:
             title = join(title, '()')
 
+        if rootdir.endswith('.pdf'):
+            full_url = full_url.replace('.html#', '_')  # for links to variables and functions
+            full_url = full_url.replace('.html', '')  # for links to files
         pnode = nodes.reference(title, title, internal=False, refuri=full_url)
         return [pnode], []
 


### PR DESCRIPTION
Support for linking to functions and variables in Doxygen's PDF output was added in PR #32. Linking to files wasn't properly supported yet. The link would open the first page of the Doxygen pdf file instead of opening the first page of the file's documentation. This PR addresses the issue.