### PR TITLE
fixes crash when template class has itself as friend

### DIFF
--- a/sphinxcontrib/doxylink/doxylink.py
+++ b/sphinxcontrib/doxylink/doxylink.py
@@ -214,6 +214,8 @@ def parse_tag_file(doc: ET.ElementTree) -> Dict[str, Union[Entry, FunctionList]]
             member_kind = member.get('kind')
             arglist_text = member.findtext('./arglist')  # If it has an <arglist> then we assume it's a function. Empty <arglist> returns '', not None. Things like typedefs and enums can have empty arglists
 
+            if member_kind == "friend": # ignore friend class definitions because it results in double class entries that will throw a RuntimeError (see below at the end of this function)
+                continue
             if arglist_text and member_kind not in {'variable', 'typedef', 'enumeration', "enumvalue"}:
                 function_list.append((member_symbol, arglist_text, member_kind, join(anchorfile, '#', member.findtext('anchor'))))
             else:

--- a/tests/test_doxylink_edge_cases.py
+++ b/tests/test_doxylink_edge_cases.py
@@ -1,0 +1,47 @@
+import xml.etree.ElementTree as ET
+from sphinxcontrib.doxylink import doxylink
+
+TEMPLATE_CLASS_WITH_SELF_FRIEND = """<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<tagfile doxygen_version="1.9.4">
+  <compound kind="file">
+    <name>base_string.h</name>
+    <path>/workspaces/test</path>
+    <filename>base__string_8h.html</filename>
+    <class kind="class">container::BaseString</class>
+    <namespace>container</namespace>
+  </compound>
+  <compound kind="class">
+    <name>container::BaseString</name>
+    <filename>classcontainer_1_1_base_string.html</filename>
+    <templarg>class T</templarg>
+    <templarg>std::size_t N</templarg>
+    <member kind="function">
+      <type></type>
+      <name>BaseString</name>
+      <anchorfile>classcontainer_1_1_base_string.html</anchorfile>
+      <anchor>e452ce3dc0c4848d8fb5f441311185dc1</anchor>
+      <arglist>()</arglist>
+    </member>
+    <member kind="friend" protection="private">
+      <type>friend class</type>
+      <name>BaseString</name>
+      <anchorfile>classcontainer_1_1_base_string.html</anchorfile>
+      <anchor>4f2bed5eca1588cf30324f67c13ca7990</anchor>
+      <arglist></arglist>
+    </member>
+  </compound>
+  <compound kind="namespace">
+    <name>container</name>
+    <filename>namespacecontainer.html</filename>
+    <class kind="class">container::BaseString</class>
+  </compound>
+</tagfile>
+"""
+
+def test_doxylink_wont_crash_on_self_friend_template_classes():
+    tag_file = ET.ElementTree(ET.fromstring(TEMPLATE_CLASS_WITH_SELF_FRIEND))
+    try:
+        doxylink.SymbolMap(tag_file)
+    except RuntimeError as exc:
+        assert False, f"template class with self friend definition raises a Runtime Error: {exc}"
+


### PR DESCRIPTION
When a template class has a friend definition with itself doxylink will crash with a runtime error saying:
"Cannot add override to non-function ..."

It seems to me that this is because the kind="friend" definition in tag file creates an "Entry" (inside the class) with the same name as the class's own constructor function.

I created a test to show the behavior and a fix to ignore friend definitions (i think it's very unlikely that someone wants to link on these definitions and also in that case the syntax would need to include the friend keyword etc.)
