### PR TITLE
Do not throw in `parse_tag_file` if the mappings is a single `Entry` instead of a `FunctionList`

### DIFF
--- a/sphinxcontrib/doxylink/doxylink.py
+++ b/sphinxcontrib/doxylink/doxylink.py
@@ -228,11 +228,13 @@ def parse_tag_file(doc: ET.ElementTree) -> Dict[str, Union[Entry, FunctionList]]
         except ParseException as e:
             print(f'Skipping {kind} {member_symbol}{arglist}. Error reported from parser was: {e}')
         else:
-            if member_symbol not in mapping:
+            if member_symbol not in mapping or isinstance(mapping[member_symbol], Entry):
                 mapping[member_symbol] = FunctionList()
             member_mapping = mapping[member_symbol]
+
             if not isinstance(member_mapping, FunctionList):
                 raise RuntimeError(f"Cannot add override to non-function '{member_symbol}'")
+
             member_mapping.add_overload(normalised_arglist, anchor_link)
 
     return mapping


### PR DESCRIPTION
I ran into a build error with the https://github.com/moveit/moveit2_tutorials repo and found that the `parse_tag_file()` had a mappings dictionary that expected entities to map to `FunctionList` objects, but many of them were `Entry` objects that could straightforwardly be packaged up into a `FunctionList` instead of throwing an exception.

I have no idea if this is correct, but it fixed the issue for me!