### PR TITLE
Make release commit with deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ jobs:
       contents: write
     steps:
       # Set things up
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}  # Use ref here since we must commit on a branch
+          ssh-key: ${{secrets.DEPLOY_KEY}}
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -68,8 +71,8 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - name: Commit and tag
         run: |
-          git config --global user.name "Matt Williams"
-          git config --global user.email "milliams@users.noreply.github.com"
+          git config --global user.name "GitHub Action"
+          git config --global user.email "action@github.com"
           git commit -m "Release ${{ steps.get_version.outputs.version }}"
           git tag "${{ steps.get_version.outputs.version }}"
           git push --atomic --tags origin HEAD


### PR DESCRIPTION
I created an SSH key locally with with:
```bash
ssh-keygen -q -t ed25519 -f ~/temp/doxylink_release_key -C '' -N ''
```
and in the `doxylink` GitHub settings page created a deploy key called "Release deploy key" with that key's public key and with write permissions. I put the private key part in an Actions secret called `DEPLOY_KEY`.

I then edited the branch protection ruleset to add Deploy Keys to the exception list.

This PR updates the release workflow to use that deploy key to check out the code so that when it pushes the tag and release commit it is allowed to bypass the PR requirement.