### PR TITLE
Expand testing; fix parsing for function-like macros 

### DIFF
--- a/sphinxcontrib/doxylink/parsing.py
+++ b/sphinxcontrib/doxylink/parsing.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 from pyparsing import Word, Literal, nums, alphanums, OneOrMore, Opt, \
     SkipTo, ParseException, Group, Combine, delimitedList, quotedString, \
-    nestedExpr, ParseResults, oneOf, ungroup, Keyword, ZeroOrMore
+    nestedExpr, ParseResults, oneOf, ungroup, Keyword, ZeroOrMore, Empty, replaceWith
 
 # define punctuation - reuse of expressions helps packratting work better
 LPAR, RPAR, LBRACK, RBRACK, LCBRACK, RCBRACK, COMMA, EQ = map(Literal, "()[]{},=")
@@ -56,8 +56,10 @@ pointer_or_reference = pointer | reference
 default_value = Literal('=') + OneOrMore(number | quotedString | input_type | parentheses_pair | angle_bracket_pair | square_bracket_pair | curly_bracket_pair | Word('|&^'))
 
 # A combination building up the interesting bit -- the argument type, e.g. 'const QString &', 'int' or 'char*'
-argument_type = Opt(qualifier, default='')("qualifier1") + \
-                input_type("input_type").setParseAction(' '.join) + \
+argument_type_prefix = (qualifier("qualifier1") + input_type("input_type").setParseAction(' '.join)) | \
+                       (Empty().setParseAction(replaceWith(''))("qualifier1") + input_type("input_type").setParseAction(' '.join))
+
+argument_type = argument_type_prefix + \
                 Opt(qualifier, default='')("qualifier2") + \
                 Group(ZeroOrMore(pointer_or_reference))("pointer_or_references") + \
                 Opt('...')("parameter_pack")
@@ -66,7 +68,7 @@ argument_type = Opt(qualifier, default='')("qualifier1") + \
 argument = Group(argument_type('argument_type') + Opt(input_name) + Opt(default_value))
 
 # List of arguments in parentheses with an optional 'const' on the end
-arglist = LPAR + delimitedList(argument)('arg_list') + Opt(COMMA + '...')('var_args') + RPAR
+arglist = LPAR + Opt(delimitedList(argument)('arg_list')) + Opt(COMMA) + Opt('...')('var_args') + RPAR
 
 
 def normalise(symbol: str) -> Tuple[str, str]:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -65,10 +65,20 @@ extern int ambiguous_var;
 /// Simple macro.
 #define SIMPLE_MACRO 42
 
-/// A function-like macro.
-#define FUNCTION_LIKE_MACRO(int x, int y);
+/// Function-like macro.
+#define FUNCTION_LIKE_MACRO_1(x)
 
+/// Function-like macro.
+#define FUNCTION_LIKE_MACRO_2(x, y);
 
+/// Variadic macro.
+#define VARIADIC_FUNCTION_LIKE_MACRO_1(...)
+
+/// Variadic macro.
+#define VARIADIC_FUNCTION_LIKE_MACRO_2(x, ...)
+
+/// Macro with a keyword as its parameter.
+#define MACRO_WITH_KEYWORD_PARAM(enum)
 """
 
 _CXX_NAMES = (
@@ -87,7 +97,11 @@ _CXX_NAMES = (
     ("secondary", "TestFunction"),
     ("secondary", "ambiguous_var"),
     (None, "SIMPLE_MACRO"),
-    (None, "FUNCTION_LIKE_MACRO"),
+    (None, "FUNCTION_LIKE_MACRO_1"),
+    (None, "FUNCTION_LIKE_MACRO_2"),
+    (None, "VARIADIC_FUNCTION_LIKE_MACRO_1"),
+    (None, "VARIADIC_FUNCTION_LIKE_MACRO_2"),
+    (None, "MACRO_WITH_KEYWORD_PARAM"),
 )
 
 # Assert that all names above are present in _CXX_SOURCE

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,206 @@
+import os
+from pathlib import Path
+import pytest
+import subprocess
+import sys
+import re
+from typing import Iterable
+
+_CXX_SOURCE = """
+namespace primary {
+
+/// Test function.
+void TestFunction();
+
+/// Function that appears in two namespaces.
+void AmbiguousFunction();
+
+/// Global variable.
+extern int global_var;
+
+/// Ambiguous variable.
+extern int ambiguous_var;
+
+/// Test class.
+class TestClass {
+public:
+  /// Method.
+  void method();
+};
+
+/// Test struct.
+struct TestStruct {
+  /// Member.
+  int member;
+};
+
+/// Test class template.
+template <typename T>
+class TestTemplate {
+public:
+  /// Test template method.
+  void init();
+};
+
+/// Test function template.
+template <typename T>
+void FunctionTemplate(T param);
+
+/// Variable template.
+template <class T>
+constexpr T variable_template = T(3.14);
+
+}  // namespace primary
+
+namespace secondary {
+
+/// Function with the same name in a different namespace.
+void AmbiguousFunction();
+
+/// Ambiguous variable in a different namespace.
+extern int ambiguous_var;
+
+}  // namespace secondary
+
+/// Simple macro.
+#define SIMPLE_MACRO 42
+
+/// A function-like macro.
+#define FUNCTION_LIKE_MACRO(int x, int y);
+
+
+"""
+
+_CXX_NAMES = (
+    ("primary", "TestFunction"),
+    ("primary", "AmbiguousFunction"),
+    ("primary", "global_var"),
+    ("primary", "TestClass"),
+    ("primary::TestClass", "method"),
+    ("primary", "TestStruct"),
+    ("primary::TestStruct", "member"),
+    ("primary", "TestTemplate"),
+    ("primary::TestTemplate", "init"),
+    ("primary", "FunctionTemplate"),
+    ("primary", "variable_template"),
+    ("primary", "ambiguous_var"),
+    ("secondary", "TestFunction"),
+    ("secondary", "ambiguous_var"),
+    (None, "SIMPLE_MACRO"),
+    (None, "FUNCTION_LIKE_MACRO"),
+)
+
+# Assert that all names above are present in _CXX_SOURCE
+assert all(name in _CXX_SOURCE for _, name in _CXX_NAMES)
+
+
+@pytest.fixture
+def doxylink_setup(tmp_path: Path) -> Path:
+    """Sets up a Sphinx project with Doxygen output for Doxylink tests."""
+    # Set up directories
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    src_dir = project_dir / "src"
+    src_dir.mkdir()
+
+    docs_dir = project_dir / "docs"
+    docs_dir.mkdir()
+
+    # Create C++ source file
+    header_file = src_dir / "test.h"
+    header_file.write_text(_CXX_SOURCE, encoding="utf-8")
+
+    # Create Doxyfile
+    doxyfile = docs_dir / "Doxyfile"
+    doxyfile.write_text(
+        f"""
+PROJECT_NAME = "Test Project"
+OUTPUT_DIRECTORY = {docs_dir / "doxygen_out"}
+GENERATE_TAGFILE = {docs_dir / "test.tag"}
+GENERATE_XML = YES
+GENERATE_HTML = YES
+INPUT = {src_dir}
+QUIET = YES
+EXTRACT_ALL = YES
+""",
+        encoding="utf-8",
+    )
+
+    # Run Doxygen
+    subprocess.check_call(["doxygen", str(doxyfile)], cwd=docs_dir)
+
+    # Verify tag file exists
+    tag_file = docs_dir / "test.tag"
+    assert tag_file.exists()
+    tag_content = tag_file.read_text(encoding="utf-8")
+    for ns, name in _CXX_NAMES:
+        assert name in tag_content, f"Tag file does not contain '{name}': {tag_content}"
+
+    # Create Sphinx conf.py
+    conf_py = docs_dir / "conf.py"
+    # We point 'html' to the doxygen html output relative to the sphinx output
+    # Since sphinx output will be in docs_dir/_build/html, and doxygen is in docs_dir/doxygen_out/html
+    # The relative path from _build/html to doxygen_out/html is ../../doxygen_out/html
+    conf_py.write_text(
+        f"""
+extensions = ['sphinxcontrib.doxylink']
+doxylink = {{
+    'test': ('{tag_file.resolve()}', '../../doxygen_out/html'),
+}}
+master_doc = 'index'
+""",
+        encoding="utf-8",
+    )
+
+    return docs_dir
+
+
+def run_sphinx(
+    docs_dir: Path,
+    out_dir: Path,
+    extra_args: Iterable[str] = (),
+    check: bool = True,
+) -> subprocess.CompletedProcess:
+    """Runs Sphinx and returns the result."""
+    cmd = [sys.executable, "-m", "sphinx", "-b", "html", *extra_args, ".", str(out_dir)]
+    return subprocess.run(
+        cmd, cwd=docs_dir, capture_output=True, text=True, check=check
+    )
+
+
+def test_doxylink_valid_links(doxylink_setup: Path) -> None:
+    """Tests that valid Doxylink links are generated."""
+    docs_dir = doxylink_setup
+
+    # Create index.rst
+    index_rst = docs_dir / "index.rst"
+    rst_lines = [
+        "Test Document",
+        "=============",
+        "",
+    ]
+    for ns, name in _CXX_NAMES:
+        qualified_name = f"{ns}::{name}" if ns else name
+        rst_lines.append(f"Link to {name}: :test:`{qualified_name}`")
+
+    index_rst.write_text("\n".join(rst_lines) + "\n", encoding="utf-8")
+
+    # Run Sphinx
+    build_dir = docs_dir / "_build"
+    run_sphinx(docs_dir, build_dir / "html")
+
+    # Verify generated HTML
+    index_html = build_dir / "html" / "index.html"
+    content = index_html.read_text(encoding="utf-8")
+
+    # Helper to verify link exists
+    def verify_link(text: str, symbol: str) -> None:
+        # Look for <a ... href="...doxygen_out/html/..." ...>...symbol...</a>
+        pattern = rf'<a\s+[^>]*href="[^"]*doxygen_out/html/[^"]*"[^>]*>.*?{re.escape(symbol)}.*?</a>'
+        assert re.search(
+            pattern, text, re.DOTALL
+        ), f"Could not find link for symbol '{symbol}'"
+
+    for ns, name in _CXX_NAMES:
+        verify_link(content, name)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,6 +7,8 @@ import pstats
 # List of tuples of: (input, correct output)
 # Input is a string, output is a tuple.
 arglists = [
+    ('(enum)', ('', '(enum)')),
+    ('(const)', ('', '(const)')),
     ('( QUrl source )', ('', '(QUrl)')),
     ('( QUrl * source )', ('', '(QUrl*)')),
     ('( QUrl ** source )', ('', '(QUrl**)')),
@@ -62,6 +64,8 @@ varargs = [
     ('fprintf( std::FILE* stream, const char* format, ... )', ('fprintf', '(std::FILE*, const char*, ...)')),
     ('sprintf( char* buffer, const char* format, ... )', ('sprintf', '(char*, const char*, ...)')),
     ('snprintf( char* buffer, std::size_t buf_size, const char* format, ... )', ('snprintf', '(char*, std::size_t, const char*, ...)')),
+    ('MACRO(...)', ('MACRO', '(...)')),
+    ('(...)', ('', '(...)')),
 ]
 
 multiple_qualifiers = [


### PR DESCRIPTION
Introduce test_e2e.py, a new end-to-end test. This test makes it simpler to reproduce issues and verify fixes for them.

Also, fix a bug with parsing single-argument variadic macros. Previously, macros like the following:
```c++
#define MY_MACRO(...)
```
could not be linked to with Doxylink. This PR fixes parsing for these macros and tests to test_parser.py and test_e2e.py.